### PR TITLE
Makefile uses sudo when necessary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,12 +45,12 @@ FISHION_DEST_PATH := $(FISH_DEST_FUNCTIONS_DIR)/fishion.fish
 
 
 install:
-	test -e $(FISH_DEST_FUNCTIONS_DIR); or $(MKDIR_PARENTS) $(FISH_DEST_FUNCTIONS_DIR)
-	$(INSTALL_DATA) fishion.fish $(FISHION_DEST_PATH)
+	test -e $(FISH_DEST_FUNCTIONS_DIR); or sudo $(MKDIR_PARENTS) $(FISH_DEST_FUNCTIONS_DIR)
+	sudo $(INSTALL_DATA) fishion.fish $(FISHION_DEST_PATH)
 
 
 uninstall:
-	test -e $(FISHION_DEST_PATH); and rm $(FISHION_DEST_PATH); or true
+	test -e $(FISHION_DEST_PATH); and sudo rm $(FISHION_DEST_PATH); or true
 
 
 # standard targets helpful for packaging

--- a/README.rst
+++ b/README.rst
@@ -36,9 +36,9 @@ The make targets would try to find the most suitable path to install fishion.
 
 .. code-block:: fish
 
-   # default mode is system wide, so admin privileges is required to write to those paths
-   ~> sudo make install
-   ~> sudo make uninstall
+   # default mode is system wide, admin privileges is required, targets use sudo
+   ~> make install
+   ~> make uninstall
 
    # set mode=user to work with user home subdirectories
    ~> make install mode=user


### PR DESCRIPTION
Running make with `sudo` could intervene with variables used in the `Makefile`. For example `$fish_function_path` may not return correct values in the `Makefile` if make is run as root.

This way is also easier, as `make install` would just work.